### PR TITLE
Add read-only iQue Player NAND support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Windows, macOS, and Linux are supported.
 * Nintendo DS / DSi
   * Nintendo DSi NAND backup ("nand\_dsi.bin")
   * Nintendo DS ROM image (".nds", ".srl")
+* iQue Player
+  * iQue Player NAND backup (read-only) ("nand.bin")
 * Nintendo Switch
   * Nintendo Switch NAND backup ("rawnand.bin")
 
@@ -134,11 +136,13 @@ Developer-unit contents are encrypted with different keys, which can be used wit
   `mount_nandtwl --console-id 4E696E74656E646F --cid 576879446F657344536945786973743F nand_dsi.bin mountpoint`
 * DSi NAND backup with a Console ID file and specified CID file:  
   `mount_nandtwl --console-id ConsoleID.bin --cid CID.bin nand_dsi.bin mountpoint`
-* Switch NAND backup  
+* iQue Player NAND backup:
+  `mount_nandbb nand.bin mountpoint`
+* Switch NAND backup:
   `mount_nandhac --keys prod.keys rawnand.bin mountpoint`
-* Switch NAND backup in multiple parts  
+* Switch NAND backup in multiple parts:
   `mount_nandhac --keys prod.keys -S rawnand.bin.00 mountpoint`
-* Switch NAND encrypted partition dump  
+* Switch NAND encrypted partition dump:
   `mount_nandhac --keys prod.keys --partition SYSTEM SYSTEM.bin mountpoint`
 * NCCH container (.app, .cxi, .cfa, .ncch):  
   `mount_ncch content.cxi mountpoint`

--- a/ninfs/gui/__init__.py
+++ b/ninfs/gui/__init__.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 from .about import NinfsAbout
 from .confighandler import get_bool, set_bool
 from .settings import NinfsSettings
-from .typeinfo import mount_types, ctr_types, twl_types, hac_types, uses_directory
+from .typeinfo import mount_types, ctr_types, twl_types, hac_types, bb_types, uses_directory
 from .updatecheck import thread_update_check
 from .wizardcontainer import WizardContainer, WizardTypeSelector, WizardFailedMount
 

--- a/ninfs/gui/setupwizard/__init__.py
+++ b/ninfs/gui/setupwizard/__init__.py
@@ -13,6 +13,7 @@ from .exefs import ExeFSSetup
 from .nandctr import CTRNandImageSetup
 from .nandhac import HACNandImageSetup
 from .nandtwl import TWLNandImageSetup
+from .nandbb import BBNandImageSetup
 from .ncch import NCCHSetup
 from .romfs import RomFSSetup
 from .sd import SDFilesystemSetup

--- a/ninfs/gui/setupwizard/nandbb.py
+++ b/ninfs/gui/setupwizard/nandbb.py
@@ -1,0 +1,33 @@
+import tkinter as tk
+from typing import TYPE_CHECKING
+
+from .base import WizardBase
+
+if TYPE_CHECKING:
+    from .. import WizardContainer
+
+
+class BBNandImageSetup(WizardBase):
+    def __init__(self, parent: 'tk.BaseWidget' = None, *, wizardcontainer: 'WizardContainer'):
+        super().__init__(parent, wizardcontainer=wizardcontainer)
+
+        def callback(*_):
+            main_file = self.main_textbox_var.get().strip()
+            self.wizardcontainer.set_next_enabled(main_file)
+
+        main_container, main_textbox, main_textbox_var = self.make_file_picker('Select the NAND file:',
+                                                                               'Select NAND file')
+        main_container.pack(fill=tk.X, expand=True)
+
+        self.main_textbox_var = main_textbox_var
+
+        main_textbox_var.trace_add('write', callback)
+
+        self.set_header_suffix('NAND')
+
+    def next_pressed(self):
+        main_file = self.main_textbox_var.get().strip()
+
+        args = ['nandbb', main_file]
+
+        self.wizardcontainer.show_mount_point_selector('NAND', args)

--- a/ninfs/gui/setupwizard/nandbb.py
+++ b/ninfs/gui/setupwizard/nandbb.py
@@ -30,4 +30,4 @@ class BBNandImageSetup(WizardBase):
 
         args = ['nandbb', main_file]
 
-        self.wizardcontainer.show_mount_point_selector('NAND', args)
+        self.wizardcontainer.show_mount_point_selector('iQue Player NAND', args)

--- a/ninfs/gui/typeinfo.py
+++ b/ninfs/gui/typeinfo.py
@@ -6,6 +6,7 @@ mount_types = {
     'nandctr': 'Nintendo 3DS NAND backup ("nand.bin")',
     'nandhac': 'Nintendo Switch NAND backup ("rawnand.bin")',
     'nandtwl': 'Nintendo DSi NAND backup ("nand_dsi.bin")',
+    'nandbb': 'iQue Player NAND backup ("nand.bin")',
     'ncch': 'NCCH (".cxi", ".cfa", ".ncch", ".app")',
     'romfs': 'Read-only Filesystem (".romfs", "romfs.bin")',
     'sd': 'SD Card Contents ("Nintendo 3DS" from SD)',
@@ -16,5 +17,6 @@ mount_types = {
 ctr_types = ('cci', 'cdn', 'cia', 'exefs', 'nandctr', 'ncch', 'romfs', 'sd', 'threedsx')
 twl_types = ('nandtwl', 'srl')
 hac_types = ('nandhac',)
+bb_types = ('nandbb',)
 
 uses_directory = ('cdn', 'sd')

--- a/ninfs/gui/wizardcontainer.py
+++ b/ninfs/gui/wizardcontainer.py
@@ -15,7 +15,7 @@ from .opendir import open_directory
 from .optionsframes import RadiobuttonContainer
 from .outputviewer import OutputViewer
 from .setupwizard import *
-from .typeinfo import mount_types, ctr_types, twl_types, hac_types
+from .typeinfo import mount_types, ctr_types, twl_types, hac_types, bb_types
 
 if TYPE_CHECKING:
     from typing import List, Type
@@ -29,6 +29,7 @@ wizard_bases = {
     'nandctr': CTRNandImageSetup,
     'nandhac': HACNandImageSetup,
     'nandtwl': TWLNandImageSetup,
+    'nandbb': BBNandImageSetup,
     'ncch': NCCHSetup,
     'romfs': RomFSSetup,
     'sd': SDFilesystemSetup,
@@ -79,6 +80,7 @@ class WizardTypeSelector(WizardBase):
         add_options('Nintendo 3DS', ctr_types)
         add_options('Nintendo DSi', twl_types)
         add_options('Nintendo Switch', hac_types)
+        add_options('iQue Player', bb_types)
 
         type_selector_var.set('Select a type')
 

--- a/ninfs/main.py
+++ b/ninfs/main.py
@@ -16,10 +16,10 @@ windows = platform in {'win32', 'cygwin'}
 
 python_cmd = 'py -3' if windows else 'python3'
 
-mount_types = ('cci', 'cdn', 'cia', 'exefs', 'nandctr', 'nandhac', 'nandtwl', 'ncch', 'romfs', 'sd', 'srl', 'threedsx',
+mount_types = ('cci', 'cdn', 'cia', 'exefs', 'nandctr', 'nandhac', 'nandtwl', 'nandbb', 'ncch', 'romfs', 'sd', 'srl', 'threedsx',
                'titledir')
 mount_aliases = {'3ds': 'cci', '3dsx': 'threedsx', 'app': 'ncch', 'csu': 'cci', 'cxi': 'ncch', 'cfa': 'ncch',
-                 'nand': 'nandctr', 'nandswitch': 'nandhac', 'nandnx': 'nandhac', 'nanddsi': 'nandtwl',  'nds': 'srl'}
+                 'nand': 'nandctr', 'nandswitch': 'nandhac', 'nandnx': 'nandhac', 'nanddsi': 'nandtwl', 'nandique': 'nandbb', 'nds': 'srl'}
 
 _path = dirname(realpath(__file__))
 if _path not in path:

--- a/ninfs/mount/nandbb.py
+++ b/ninfs/mount/nandbb.py
@@ -159,7 +159,7 @@ def main(prog: str = None, args: list = None):
     if args is None:
         args = argv[1:]
     parser = ArgumentParser(prog=prog, description='Mount iQue Player NAND images.',
-                            parents=(_c.default_argp, _c.readonly_argp, _c.main_args('nand', 'iQue Player NAND image')))
+                            parents=(_c.default_argp, _c.main_args('nand', 'iQue Player NAND image')))
     
     a = parser.parse_args(args)
     opts = dict(_c.parse_fuse_opts(a.o))

--- a/ninfs/mount/nandbb.py
+++ b/ninfs/mount/nandbb.py
@@ -83,7 +83,7 @@ class BBNandImageMount(LoggingMixIn, Operations):
                 ext = entry[8:11].decode().rstrip("\x00")
                 size = readbe(entry[16:20])
                 self.files[f'/{name}.{ext}'] = {'start': start, 'size': size}
-                self.used += size
+                self.used += size // 0x4000
         
         fat = bbfs_blocks[latest_bbfs_block][:0x2000]
         
@@ -146,7 +146,7 @@ class BBNandImageMount(LoggingMixIn, Operations):
     
     @_c.ensure_lower_path
     def statfs(self, path):
-        return {'f_bsize': 0x4000, 'f_blocks': 0x4000000 // 0x4000, 'f_bavail': 0xFF0 - 0x40 - (self.used // 0x4000), 'f_bfree': 0xFF0 - 0x40 - (self.used // 0x4000),
+        return {'f_bsize': 0x4000, 'f_blocks': 0xFF0 - 0x40, 'f_bavail': 0xFF0 - 0x40 - self.used, 'f_bfree': 0xFF0 - 0x40 - self.used,
                 'f_files': len(self.files)}
     
     @_c.ensure_lower_path

--- a/ninfs/mount/nandbb.py
+++ b/ninfs/mount/nandbb.py
@@ -1,0 +1,178 @@
+"""
+Mounts iQue Player NAND images, creating a virtual filesystem of the files contained within.
+"""
+
+import logging
+from errno import ENOENT, EROFS
+from stat import S_IFDIR, S_IFREG
+from sys import exit, argv
+from typing import BinaryIO
+
+from pyctr.util import readbe
+
+from . import _common as _c
+# _common imports these from fusepy, and prints an error if it fails; this allows less duplicated code
+from ._common import FUSE, FuseOSError, Operations, LoggingMixIn, fuse_get_context, get_time, realpath
+
+class BBNandImageMount(LoggingMixIn, Operations):
+    fd = 0
+    
+    def __init__(self, nand_fp: BinaryIO, g_stat: dict):
+        self.g_stat = g_stat
+        
+        self.files = {}
+        
+        self.f = nand_fp
+        
+        nand_size = nand_fp.seek(0, 2)
+        if nand_size != 0x4000000:
+            exit(f'NAND size is incorrect (expected 0x4000000, got {nand_size:#X})')
+        
+        bbfs_blocks = []
+        nand_fp.seek(0xFF0 * 0x4000)
+        for i in range(0x10):
+            bbfs_blocks.append(nand_fp.read(0x4000))
+        
+        nand_fp.seek(0)
+        
+        latest_seqno = -1
+        latest_bbfs_block = None
+        
+        for i, j in enumerate(bbfs_blocks):
+            header = j[0x3FF4:]
+            
+            magic = header[:4]
+            if magic == b"\0x00\0x00\0x00\0x00":
+                continue
+            if magic not in [b"BBFS", b"BBFL"]:
+                exit(f'Invalid BBFS magic: expected b"BBFS" or b"BBFL", got {magic.hex().upper()}')
+            
+            calculated_checksum = 0
+            for k in range(0, 0x4000, 2):
+                calculated_checksum += readbe(j[k:k + 2])
+            
+            if calculated_checksum & 0xFFFF != 0xCAD7:
+                exit(f'BBFS block {i} has an invalid checksum')
+            
+            seqno = readbe(header[4:8])
+            if seqno > latest_seqno:
+                latest_seqno = seqno
+                latest_bbfs_block = i
+        
+        if latest_bbfs_block == None or latest_seqno == -1:
+            exit(f'Blank BBFS (all BBFS magics were 00000000)')
+        
+        for i in range(0x2000, 0x3FF4, 0x14):
+            entry = bbfs_blocks[latest_bbfs_block][i:i + 0x14]
+            valid = bool(entry[11])
+            if valid:
+                name = entry[:8].decode().rstrip("\x00")
+                ext = entry[8:11].decode().rstrip("\x00")
+                self.files[f'/{name}.{ext}'] = {'start': readbe(entry[12:14]), 'size': readbe(entry[16:20])}
+        
+        fat = bbfs_blocks[latest_bbfs_block][:0x2000]
+        
+        self.fat_entries = []
+        for i in range(0, len(fat), 2):
+            u = readbe(fat[i:i + 2])
+            s = u - (u & 0x8000) * 2
+            self.fat_entries.append(s)
+    
+    def __del__(self, *args):
+        try:
+            self.f.close()
+        except AttributeError:
+            pass
+    
+    destroy = __del__
+    
+    def flush(self, path, fh):
+        return self.f.flush()
+    
+    @_c.ensure_lower_path
+    def getattr(self, path, fh=None):
+        uid, gid, pid = fuse_get_context()
+        if path == '/':
+            st = {'st_mode': (S_IFDIR | (0o555)), 'st_nlink': 2}
+        elif path in self.files:
+            st = {'st_mode': (S_IFREG | (0o444)),
+                  'st_size': self.files[path]['size'], 'st_nlink': 1}
+        else:
+            raise FuseOSError(ENOENT)
+        return {**st, **self.g_stat, 'st_uid': uid, 'st_gid': gid}
+    
+    def open(self, path, flags):
+        self.fd += 1
+        return self.fd
+    
+    @_c.ensure_lower_path
+    def readdir(self, path, fh):
+        yield from ('.', '..')
+        yield from (x[1:] for x in self.files)
+    
+    @_c.ensure_lower_path
+    def read(self, path, size, offset, fh):
+        fi = self.files[path]
+        
+        if offset > fi['size']:
+            return b''
+        
+        data = bytearray()
+        
+        block = fi['start']
+        while True:
+            self.f.seek(block * 0x4000)
+            data.extend(self.f.read(0x4000))
+            block = self.fat_entries[block]
+            if block == -1:
+                break
+            if block in [0, -2, -3]:
+                return b''
+        
+        if len(data) != fi['size']:
+            return b''
+        
+        if offset + size > fi['size']:
+            size = fi['size'] - offset
+        
+        return bytes(data[offset:offset + size])
+    
+    @_c.ensure_lower_path
+    def statfs(self, path):
+        return {'f_bsize': 4096, 'f_blocks': 0x4000000 // 4096, 'f_bavail': 0, 'f_bfree': 0,
+                'f_files': len(self.files)}
+    
+    @_c.ensure_lower_path
+    def write(self, path, data, offset, fh):
+        raise FuseOSError(EROFS)
+
+
+def main(prog: str = None, args: list = None):
+    from argparse import ArgumentParser
+    if args is None:
+        args = argv[1:]
+    parser = ArgumentParser(prog=prog, description='Mount iQue Player NAND images.',
+                            parents=(_c.default_argp, _c.readonly_argp, _c.main_args('nand', 'iQue Player NAND image')))
+    
+    a = parser.parse_args(args)
+    opts = dict(_c.parse_fuse_opts(a.o))
+    
+    if a.do:
+        logging.basicConfig(level=logging.DEBUG, filename=a.do)
+    
+    nand_stat = get_time(a.nand)
+    
+    with open(a.nand, 'rb') as f:
+        mount = BBNandImageMount(nand_fp=f, g_stat=nand_stat)
+        if _c.macos or _c.windows:
+            opts['fstypename'] = 'BBFS'
+            # assuming / is the path separator since macos. but if windows gets support for this,
+            #   it will have to be done differently.
+            if _c.macos:
+                path_to_show = realpath(a.nand).rsplit('/', maxsplit=2)
+                opts['volname'] = f'iQue Player NAND ({path_to_show[-2]}/{path_to_show[-1]})'
+            elif _c.windows:
+                # volume label can only be up to 32 chars
+                opts['volname'] = 'iQue Player NAND'
+        FUSE(mount, a.mount_point, foreground=a.fg or a.d, ro=True, nothreads=True, debug=a.d,
+             fsname=realpath(a.nand).replace(',', '_'), **opts)

--- a/ninfs/mount/nandbb.py
+++ b/ninfs/mount/nandbb.py
@@ -146,7 +146,7 @@ class BBNandImageMount(LoggingMixIn, Operations):
     
     @_c.ensure_lower_path
     def statfs(self, path):
-        return {'f_bsize': 0x4000, 'f_blocks': 0xFF0 - 0x40, 'f_bavail': 0xFF0 - 0x40 - self.used, 'f_bfree': 0xFF0 - 0x40 - self.used,
+        return {'f_bsize': 0x4000, 'f_frsize': 0x4000, 'f_blocks': 0xFF0 - 0x40, 'f_bavail': 0xFF0 - 0x40 - self.used, 'f_bfree': 0xFF0 - 0x40 - self.used,
                 'f_files': len(self.files)}
     
     @_c.ensure_lower_path

--- a/setup-cxfreeze.py
+++ b/setup-cxfreeze.py
@@ -12,6 +12,7 @@ build_exe_options = {
         'ninfs.mount.nandctr',
         'ninfs.mount.nandhac',
         'ninfs.mount.nandtwl',
+        'ninfs.mount.nandbb',
         'ninfs.mount.ncch',
         'ninfs.mount.romfs',
         'ninfs.mount.sd',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
                                       'mount_nandctr = ninfs.main:main',
                                       'mount_nandtwl = ninfs.main:main',
                                       'mount_nandhac = ninfs.main:main',
+                                      'mount_nandbb = ninfs.main:main',
                                       'mount_ncch = ninfs.main:main',
                                       'mount_romfs = ninfs.main:main',
                                       'mount_sd = ninfs.main:main',
@@ -65,6 +66,7 @@ setup(
                                       'mount_cfa = ninfs.main:main',
                                       'mount_nand = ninfs.main:main',
                                       'mount_nanddsi = ninfs.main:main',
+                                      'mount_nandique = ninfs.main:main',
                                       'mount_nandswitch = ninfs.main:main',
                                       'mount_nandnx = ninfs.main:main',
                                       'mount_nds = ninfs.main:main']}


### PR DESCRIPTION
Initial support for reading iQue Player NAND dumps. Needs testing.
[Example NAND dump](https://mega.nz/file/tQgAAQgB#6AzIG6uoZmipuCIfgzBCP6jCYw00T_GMXxa6yoUJcxc)